### PR TITLE
fix(bower.json): missing "ignore" entry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "private": false,
+  "ignore": [],
   "dependencies": {
     "angular": "1.3.6",
     "angular-animate": "1.3.6",


### PR DESCRIPTION
ignore is not an optional entry in bower.json
i'm have this error in console when update nightly bower in every day!
`invalid-meta ionic is missing "ignore" entry in bower.json`
