### PR TITLE
Including ionic.bundle.js as part of the bower.config main section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
     "css/ionic.css",
     "fonts/*",
     "js/ionic.js",
-    "js/ionic-angular.js"
+    "js/ionic-angular.js",
+    "js/ionic.bundle.js"
   ],
   "keywords": [
     "mobile",


### PR DESCRIPTION
Given the recommended approach is to reference ionic.bundle.js it makes sense it is part of the main files list.

Also simplifies the usage of https://github.com/blittle/bower-installer