### PR TITLE
Using Angular 1.5.x instead of 1.5.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,9 +29,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "angular": "1.5.3",
-    "angular-animate": "1.5.3",
-    "angular-sanitize": "1.5.3",
+    "angular": "~1.5",
+    "angular-animate": "~1.5",
+    "angular-sanitize": "~1.5",
     "angular-ui-router": "0.2.13"
   }
 }


### PR DESCRIPTION
Solves issue #36 by providing a more flexible version requirement for Angular dependencies.